### PR TITLE
Add core migrations with Passport tables

### DIFF
--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_auth_codes', function (Blueprint $table) {
+            $table->string('id', 100)->primary();
+            $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnDelete()->index();
+            $table->foreignId('client_id')->constrained('oauth_clients')->cascadeOnDelete()->index();
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked')->default(false);
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_auth_codes');
+    }
+};

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_access_tokens', function (Blueprint $table) {
+            $table->string('id', 100)->primary();
+            $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnDelete()->index();
+            $table->foreignId('client_id')->constrained('oauth_clients')->cascadeOnDelete()->index();
+            $table->string('name')->nullable();
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked')->default(false);
+            $table->dateTime('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_access_tokens');
+    }
+};

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
+            $table->string('id', 100)->primary();
+            $table->string('access_token_id', 100)->index();
+            $table->boolean('revoked')->default(false);
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_refresh_tokens');
+    }
+};

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_clients', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('name');
+            $table->string('secret', 100)->nullable();
+            $table->text('redirect');
+            $table->boolean('personal_access_client');
+            $table->boolean('password_client');
+            $table->boolean('revoked')->default(false);
+            $table->string('provider')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_clients');
+    }
+};

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('client_id')->constrained('oauth_clients')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_personal_access_clients');
+    }
+};

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -10,20 +10,20 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->uuid('uuid')->unique();
+            $table->morphs('tokenable');
             $table->string('name');
-            $table->string('email')->unique();
-            $table->string('password');
-            $table->foreignId('plan_id')->nullable()->constrained('plans')->cascadeOnDelete();
-            $table->rememberToken();
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
             $table->timestamps();
         });
     }
 
     public function down(): void
     {
-        Schema::dropIfExists('users');
+        Schema::dropIfExists('personal_access_tokens');
     }
 };

--- a/database/migrations/2024_01_01_000001_create_emotion_inputs_table.php
+++ b/database/migrations/2024_01_01_000001_create_emotion_inputs_table.php
@@ -1,2 +1,0 @@
-<?php
-// Placeholder migration for emotion_inputs

--- a/database/migrations/2024_01_01_000001_create_plans_table.php
+++ b/database/migrations/2024_01_01_000001_create_plans_table.php
@@ -10,20 +10,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('plans', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->uuid('uuid')->unique();
             $table->string('name');
-            $table->string('email')->unique();
-            $table->string('password');
-            $table->foreignId('plan_id')->nullable()->constrained('plans')->cascadeOnDelete();
-            $table->rememberToken();
+            $table->text('description')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->json('features')->nullable();
+            $table->boolean('is_active')->default(true);
             $table->timestamps();
         });
     }
 
     public function down(): void
     {
-        Schema::dropIfExists('users');
+        Schema::dropIfExists('plans');
     }
 };

--- a/database/migrations/2024_01_01_000002_create_emotion_patterns_table.php
+++ b/database/migrations/2024_01_01_000002_create_emotion_patterns_table.php
@@ -1,2 +1,0 @@
-<?php
-// Placeholder migration for emotion_patterns

--- a/database/migrations/2024_01_01_000002_create_subscriptions_table.php
+++ b/database/migrations/2024_01_01_000002_create_subscriptions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('plan_id')->constrained('plans')->cascadeOnDelete();
+            $table->enum('status', ['active', 'cancelled', 'expired']);
+            $table->dateTime('started_at');
+            $table->dateTime('expires_at');
+            $table->dateTime('cancelled_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/database/migrations/2024_01_01_000003_create_emotion_inputs_table.php
+++ b/database/migrations/2024_01_01_000003_create_emotion_inputs_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('emotion_inputs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('emotion');
+            $table->text('description')->nullable();
+            $table->dateTime('registered_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('emotion_inputs');
+    }
+};

--- a/database/migrations/2024_01_01_000003_create_insights_table.php
+++ b/database/migrations/2024_01_01_000003_create_insights_table.php
@@ -1,2 +1,0 @@
-<?php
-// Placeholder migration for insights

--- a/database/migrations/2024_01_01_000004_create_emotion_patterns_table.php
+++ b/database/migrations/2024_01_01_000004_create_emotion_patterns_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('emotion_patterns', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->text('pattern');
+            $table->dateTime('detected_on');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('emotion_patterns');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_insights_table.php
+++ b/database/migrations/2024_01_01_000005_create_insights_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('insights', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->text('insight');
+            $table->dateTime('generated_on');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('insights');
+    }
+};


### PR DESCRIPTION
## Summary
- implement the main tables (users, plans, subscriptions, emotion inputs, emotion patterns, insights)
- include Laravel Passport's default tables

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b5e89ad483278f2cd9b195c53410